### PR TITLE
Fix xAPI reliability: transient vs permanent errors and stuck process…

### DIFF
--- a/Cite.Api/Controllers/XApiController.cs
+++ b/Cite.Api/Controllers/XApiController.cs
@@ -35,9 +35,7 @@ namespace Cite.Api.Controllers
         [SwaggerOperation(OperationId = "observedEvaluationDashboard")]
         public async Task<IActionResult> ObservedEvaluationDashboard(Guid evaluationId, Guid teamId, CancellationToken ct)
         {
-            if (!await _xApiService.EvaluationDashboardObservedAsync(evaluationId, teamId, ct))
-                throw new Exception();
-
+            await _xApiService.EvaluationDashboardObservedAsync(evaluationId, teamId, ct);
             return Ok();
         }
 
@@ -56,9 +54,7 @@ namespace Cite.Api.Controllers
         [SwaggerOperation(OperationId = "observedEvaluationScoresheet")]
         public async Task<IActionResult> ObservedEvaluationScoresheet(Guid evaluationId, Guid teamId, CancellationToken ct)
         {
-            if (!await _xApiService.EvaluationScoresheetObservedAsync(evaluationId, teamId, ct))
-                throw new Exception();
-
+            await _xApiService.EvaluationScoresheetObservedAsync(evaluationId, teamId, ct);
             return Ok();
         }
     }

--- a/Cite.Api/Infrastructure/Options/XApiOptions.cs
+++ b/Cite.Api/Infrastructure/Options/XApiOptions.cs
@@ -8,6 +8,7 @@ namespace Cite.Api.Infrastructure.Options
 {
     public class XApiOptions
     {
+        public bool Enabled { get; set; }
         public string Endpoint { get; set; }
         public string Username { get; set; }
         public string Password { get; set; }

--- a/Cite.Api/Infrastructure/Options/XApiOptions.cs
+++ b/Cite.Api/Infrastructure/Options/XApiOptions.cs
@@ -17,5 +17,7 @@ namespace Cite.Api.Infrastructure.Options
         public string EmailDomain { get; set; }
         public string Platform { get; set; }
         public int RetentionDays { get; set; } = 7;
+        public int ProcessingTimeoutMinutes { get; set; } = 10;
+        public int ProcessingDelaySeconds { get; set; } = 30;
     }
 }

--- a/Cite.Api/Services/XApiBackgroundService.cs
+++ b/Cite.Api/Services/XApiBackgroundService.cs
@@ -20,7 +20,6 @@ namespace Cite.Api.Services
     {
         private readonly IServiceProvider _serviceProvider;
         private readonly ILogger<XApiBackgroundService> _logger;
-        private const int ProcessingDelaySeconds = 5;
         private const int BatchSize = 10;
         private const int CleanupDelayHours = 24;
 
@@ -36,7 +35,8 @@ namespace Cite.Api.Services
         {
             _logger.LogInformation("xAPI Background Service started");
 
-            // Check if xAPI is configured (get from scope)
+            // Check if xAPI is configured and get processing delay (get from scope)
+            int processingDelaySeconds;
             using (var scope = _serviceProvider.CreateScope())
             {
                 var xApiOptions = scope.ServiceProvider.GetRequiredService<XApiOptions>();
@@ -45,6 +45,7 @@ namespace Cite.Api.Services
                     _logger.LogInformation("xAPI is not configured. Background service will not process statements.");
                     return;
                 }
+                processingDelaySeconds = xApiOptions.ProcessingDelaySeconds > 0 ? xApiOptions.ProcessingDelaySeconds : 30;
             }
 
             DateTime lastCleanup = DateTime.MinValue;
@@ -74,10 +75,52 @@ namespace Cite.Api.Services
                 }
 
                 // Wait before processing next batch
-                await Task.Delay(TimeSpan.FromSeconds(ProcessingDelaySeconds), stoppingToken);
+                await Task.Delay(TimeSpan.FromSeconds(processingDelaySeconds), stoppingToken);
             }
 
             _logger.LogInformation("xAPI Background Service stopped");
+        }
+
+        private static bool IsTransientError(HttpResponseMessage response, Exception ex)
+        {
+            // Check HTTP status codes
+            if (response != null)
+            {
+                var statusCode = (int)response.StatusCode;
+
+                // Transient HTTP errors
+                if (statusCode == 429 || statusCode == 500 || statusCode == 502 ||
+                    statusCode == 503 || statusCode == 504)
+                {
+                    return true;
+                }
+
+                // Permanent HTTP errors
+                if (statusCode == 400 || statusCode == 401 || statusCode == 403 || statusCode == 422)
+                {
+                    return false;
+                }
+
+                // Any other non-success status: treat as transient (conservative approach)
+                return true;
+            }
+
+            // Check exception types
+            if (ex != null)
+            {
+                // Timeout and network errors are transient
+                if (ex is TaskCanceledException ||
+                    ex is OperationCanceledException ||
+                    ex is HttpRequestException)
+                {
+                    return true;
+                }
+
+                // Unknown exceptions: treat as transient (conservative approach)
+                return true;
+            }
+
+            return true; // Default to transient
         }
 
         private async Task ProcessQueueAsync(CancellationToken cancellationToken)
@@ -104,29 +147,58 @@ namespace Cite.Api.Services
             // Process each statement
             foreach (var queuedStatement in statements)
             {
+                HttpResponseMessage response = null;
+                Exception caughtException = null;
+
                 try
                 {
                     // Send raw JSON directly to LRS
                     var content = new StringContent(queuedStatement.StatementJson, Encoding.UTF8, "application/json");
-                    var response = await httpClient.PostAsync($"{xApiOptions.Endpoint}/statements", content, cancellationToken);
+                    response = await httpClient.PostAsync($"{xApiOptions.Endpoint}/statements", content, cancellationToken);
 
                     if (response.IsSuccessStatusCode)
                     {
                         await queueService.MarkCompletedAsync(queuedStatement.Id, cancellationToken);
                         _logger.LogInformation("Successfully sent xAPI statement {StatementId} to LRS", queuedStatement.Id);
                     }
+                    else if ((int)response.StatusCode == 409)
+                    {
+                        // HTTP 409 Conflict - statement already exists, treat as success
+                        await queueService.MarkCompletedAsync(queuedStatement.Id, cancellationToken);
+                        _logger.LogInformation(
+                            "xAPI statement {StatementId} already exists in LRS (HTTP 409), marking as completed",
+                            queuedStatement.Id);
+                    }
                     else
                     {
                         var errorBody = await response.Content.ReadAsStringAsync(cancellationToken);
-                        await queueService.MarkFailedAsync(queuedStatement.Id, $"HTTP {response.StatusCode}: {errorBody}", cancellationToken);
-                        _logger.LogWarning("Failed to send xAPI statement {StatementId}: HTTP {StatusCode} - {Error}",
-                            queuedStatement.Id, response.StatusCode, errorBody);
+                        bool isTransient = IsTransientError(response, null);
+                        await queueService.MarkFailedAsync(
+                            queuedStatement.Id,
+                            $"HTTP {response.StatusCode}: {errorBody}",
+                            isTransient,
+                            cancellationToken);
+
+                        var logLevel = isTransient ? LogLevel.Warning : LogLevel.Error;
+                        _logger.Log(logLevel,
+                            "Failed to send xAPI statement {StatementId}: HTTP {StatusCode} ({ErrorType}) - {Error}",
+                            queuedStatement.Id, response.StatusCode, isTransient ? "Transient" : "Permanent", errorBody);
                     }
                 }
                 catch (Exception ex)
                 {
-                    await queueService.MarkFailedAsync(queuedStatement.Id, ex.Message, cancellationToken);
-                    _logger.LogError(ex, "Error processing xAPI statement {StatementId}", queuedStatement.Id);
+                    caughtException = ex;
+                    bool isTransient = IsTransientError(null, ex);
+                    await queueService.MarkFailedAsync(
+                        queuedStatement.Id,
+                        $"{ex.GetType().Name}: {ex.Message}",
+                        isTransient,
+                        cancellationToken);
+
+                    var logLevel = isTransient ? LogLevel.Warning : LogLevel.Error;
+                    _logger.Log(logLevel, ex,
+                        "Error processing xAPI statement {StatementId} ({ErrorType})",
+                        queuedStatement.Id, isTransient ? "Transient" : "Permanent");
                 }
             }
         }
@@ -137,24 +209,35 @@ namespace Cite.Api.Services
             var queueService = scope.ServiceProvider.GetRequiredService<IXApiQueueService>();
             var xApiOptions = scope.ServiceProvider.GetRequiredService<XApiOptions>();
 
-            var cutoffDate = DateTime.UtcNow.AddDays(-xApiOptions.RetentionDays);
+            var retentionCutoff = DateTime.UtcNow.AddDays(-xApiOptions.RetentionDays);
+            var processingStuckThreshold = DateTime.UtcNow.AddMinutes(-xApiOptions.ProcessingTimeoutMinutes);
 
-            _logger.LogInformation("Cleaning up xAPI statements older than {CutoffDate} (Retention: {RetentionDays} days)", 
-                cutoffDate, xApiOptions.RetentionDays);
+            _logger.LogInformation(
+                "Starting xAPI cleanup - RetentionCutoff: {RetentionCutoff}, ProcessingStuckThreshold: {ProcessingStuckThreshold}",
+                retentionCutoff, processingStuckThreshold);
 
-            var completedStatements = await queueService.GetOldCompletedStatementsAsync(cutoffDate, cancellationToken);
-            var failedStatements = await queueService.GetOldFailedStatementsAsync(cutoffDate, cancellationToken);
+            var completedStatements = await queueService.GetOldCompletedStatementsAsync(retentionCutoff, cancellationToken);
+            var failedStatements = await queueService.GetOldFailedStatementsAsync(retentionCutoff, cancellationToken);
+            var stuckProcessingStatements = await queueService.GetStuckProcessingStatementsAsync(processingStuckThreshold, cancellationToken);
 
-            var totalStatements = completedStatements.Count + failedStatements.Count;
+            var totalStatements = completedStatements.Count + failedStatements.Count + stuckProcessingStatements.Count;
 
             if (totalStatements == 0)
             {
-                _logger.LogInformation("No old statements to cleanup");
+                _logger.LogInformation("No statements to cleanup");
                 return;
             }
 
+            // Log detailed breakdown for visibility
+            _logger.LogWarning(
+                "Cleanup summary - Completed: {Completed}, Failed: {Failed}, StuckProcessing: {StuckTotal}",
+                completedStatements.Count,
+                failedStatements.Count,
+                stuckProcessingStatements.Count);
+
             var allStatementIds = completedStatements.Select(s => s.Id)
                 .Concat(failedStatements.Select(s => s.Id))
+                .Concat(stuckProcessingStatements.Select(s => s.Id))
                 .ToList();
 
             await queueService.DeleteStatementsAsync(allStatementIds, cancellationToken);

--- a/Cite.Api/Services/XApiQueueService.cs
+++ b/Cite.Api/Services/XApiQueueService.cs
@@ -18,10 +18,11 @@ namespace Cite.Api.Services
         Task EnqueueAsync(XApiQueuedStatementEntity statement, CancellationToken ct = default);
         Task<List<XApiQueuedStatementEntity>> DequeueAsync(int batchSize = 10, CancellationToken ct = default);
         Task MarkCompletedAsync(Guid statementId, CancellationToken ct = default);
-        Task MarkFailedAsync(Guid statementId, string errorMessage, CancellationToken ct = default);
+        Task MarkFailedAsync(Guid statementId, string errorMessage, bool isTransientError, CancellationToken ct = default);
         Task<int> GetQueueDepthAsync(CancellationToken ct = default);
         Task<List<XApiQueuedStatementEntity>> GetOldCompletedStatementsAsync(DateTime cutoffDate, CancellationToken ct = default);
         Task<List<XApiQueuedStatementEntity>> GetOldFailedStatementsAsync(DateTime cutoffDate, CancellationToken ct = default);
+        Task<List<XApiQueuedStatementEntity>> GetStuckProcessingStatementsAsync(DateTime stuckThreshold, CancellationToken ct = default);
         Task DeleteStatementsAsync(List<Guid> statementIds, CancellationToken ct = default);
     }
 
@@ -29,7 +30,6 @@ namespace Cite.Api.Services
     {
         private readonly CiteContext _context;
         private readonly ILogger<XApiQueueService> _logger;
-        private const int MaxRetryCount = 5;
 
         public XApiQueueService(
             CiteContext context,
@@ -53,9 +53,9 @@ namespace Cite.Api.Services
 
         public async Task<List<XApiQueuedStatementEntity>> DequeueAsync(int batchSize = 10, CancellationToken ct = default)
         {
-            // Get pending statements that haven't exceeded retry count
+            // Get pending statements (no retry count limit - transient errors retry indefinitely)
             var statements = await _context.XApiQueuedStatements
-                .Where(s => s.Status == XApiQueueStatus.Pending && s.RetryCount < MaxRetryCount)
+                .Where(s => s.Status == XApiQueueStatus.Pending)
                 .OrderBy(s => s.QueuedAt)
                 .Take(batchSize)
                 .ToListAsync(ct);
@@ -92,7 +92,7 @@ namespace Cite.Api.Services
             _logger.LogDebug("Marked xAPI statement {StatementId} as completed", statementId);
         }
 
-        public async Task MarkFailedAsync(Guid statementId, string errorMessage, CancellationToken ct = default)
+        public async Task MarkFailedAsync(Guid statementId, string errorMessage, bool isTransientError, CancellationToken ct = default)
         {
             var statement = await _context.XApiQueuedStatements.FindAsync(new object[] { statementId }, ct);
             if (statement == null)
@@ -101,21 +101,28 @@ namespace Cite.Api.Services
                 return;
             }
 
-            statement.Status = statement.RetryCount >= MaxRetryCount
-                ? XApiQueueStatus.Failed
-                : XApiQueueStatus.Pending; // Will retry if under limit
-            statement.ErrorMessage = errorMessage;
-
-            await _context.SaveChangesAsync(ct);
-
-            if (statement.Status == XApiQueueStatus.Failed)
+            if (isTransientError)
             {
-                _logger.LogError("xAPI statement {StatementId} failed after {RetryCount} attempts: {Error}",
+                // Transient error - keep retrying indefinitely
+                statement.Status = XApiQueueStatus.Pending;
+                statement.ErrorMessage = $"[TRANSIENT] {errorMessage}";
+
+                await _context.SaveChangesAsync(ct);
+
+                _logger.LogWarning(
+                    "xAPI statement {StatementId} encountered transient error on attempt {RetryCount}, will retry: {Error}",
                     statementId, statement.RetryCount, errorMessage);
             }
             else
             {
-                _logger.LogWarning("xAPI statement {StatementId} failed attempt {RetryCount}, will retry: {Error}",
+                // Permanent error - mark as failed immediately
+                statement.Status = XApiQueueStatus.Failed;
+                statement.ErrorMessage = $"[PERMANENT] {errorMessage}";
+
+                await _context.SaveChangesAsync(ct);
+
+                _logger.LogError(
+                    "xAPI statement {StatementId} encountered permanent error after {RetryCount} attempts: {Error}",
                     statementId, statement.RetryCount, errorMessage);
             }
         }
@@ -137,6 +144,15 @@ namespace Cite.Api.Services
         {
             return await _context.XApiQueuedStatements
                 .Where(s => s.Status == XApiQueueStatus.Failed && s.QueuedAt < cutoffDate)
+                .ToListAsync(ct);
+        }
+
+        public async Task<List<XApiQueuedStatementEntity>> GetStuckProcessingStatementsAsync(DateTime stuckThreshold, CancellationToken ct = default)
+        {
+            return await _context.XApiQueuedStatements
+                .Where(s => s.Status == XApiQueueStatus.Processing
+                         && s.LastAttemptAt.HasValue
+                         && s.LastAttemptAt.Value < stuckThreshold)
                 .ToListAsync(ct);
         }
 

--- a/Cite.Api/Services/XApiService.cs
+++ b/Cite.Api/Services/XApiService.cs
@@ -92,7 +92,7 @@ namespace Cite.Api.Services
 
         public Boolean IsConfigured()
         {
-            return !string.IsNullOrWhiteSpace(_xApiOptions.Username);
+            return _xApiOptions.Enabled && !string.IsNullOrWhiteSpace(_xApiOptions.Username);
         }
 
         public async Task<Boolean> CreateAsync(

--- a/Cite.Api/appsettings.json
+++ b/Cite.Api/appsettings.json
@@ -59,7 +59,9 @@
     "UiUrl": "",
     "EmailDomain": "",
     "Platform": "",
-    "RetentionDays": 7
+    "RetentionDays": 7,
+    "ProcessingTimeoutMinutes": 10,
+    "ProcessingDelaySeconds": 30
   },
   "ResourceOwnerAuthorization": {
     "Authority": "http://localhost:8080/realms/crucible",


### PR DESCRIPTION
…ing cleanup

- Remove MaxRetryCount constant - transient errors now retry indefinitely
- Add error classification (transient/permanent) in IsTransientError method
- Transient errors (timeouts, 429, 5xx) stay Pending and retry
- Permanent errors (400, 401, 403, 422) mark as Failed immediately
- HTTP 409 Conflict treated as success (idempotent statement already exists)
- Add ProcessingTimeoutMinutes (default 10) and ProcessingDelaySeconds (default 30) config
- Increase retry delay from 5 to 30 seconds (configurable)
- Add GetStuckProcessingStatementsAsync to find orphaned Processing records
- CleanupOldStatementsAsync now includes stuck Processing records in cleanup
- Update IXApiQueueService.MarkFailedAsync signature to accept isTransientError parameter